### PR TITLE
Change phraseapp text & url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Open Source Love](https://img.shields.io/badge/opensource-we--love--open--source-34495e?style=flat-square)](https://opensource.org/licenses/gpl-3.0)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-009cde.svg?style=flat-square)](https://www.paypal.me/RDTalstra)
 <span class="badge-patreon"><a href="https://www.patreon.com/Pterodactyl_app" title="Donate to this project using Patreon"><img src="https://img.shields.io/badge/Donate-Patreon-f96854.svg?style=flat-square" alt="Patreon donate button" /></a></span>
-[![PhraseApp](https://img.shields.io/badge/PhraseApp-Using-blue?style=flat-square)](https://phrase.com/)
+[![PhraseApp](https://img.shields.io/badge/Translate-PhraseApp-blue?style=flat-square)](https://pterodactyl-app.com/phraseapp.php)
 ![GitHub stars](https://img.shields.io/github/stars/pterodactyl-app/Pterodactyl-app?style=social)
 
 A unofficial mobile app for the Pterodactyl Panel


### PR DESCRIPTION
Changed the phraseapp badge (for consistency) & url (signup page instead of the phraseapp homepage)
